### PR TITLE
updated info for supported devices of M7 processor (in Motion Activity Tracking)

### DIFF
--- a/iOS7Sampler/SampleViewControllers/ActivityTrackingViewController.m
+++ b/iOS7Sampler/SampleViewControllers/ActivityTrackingViewController.m
@@ -69,7 +69,7 @@
     
     if (!([CMStepCounter isStepCountingAvailable] || [CMMotionActivityManager isActivityAvailable])) {
         
-        NSString *msg = @"CMStepCounter and CMMotionActivityManager are not available. These classes need M7 coprocessor, so this sample works only on iPhone5s.";
+        NSString *msg = @"CMStepCounter and CMMotionActivityManager are not available. These classes need M7 coprocessor, so this sample currently works only on iPhone5s, iPad Air and iPad mini with Retina display.";
         UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"Not Supported"
                                                         message:msg
                                                        delegate:nil


### PR DESCRIPTION
updated the devices which utilize the M7 motion co-processor (iPhone5S, iPad Air and iPad mini Retina display)
